### PR TITLE
Update instance scheduler cross account role

### DIFF
--- a/source/cloudformation/instance-scheduler-remote.template
+++ b/source/cloudformation/instance-scheduler-remote.template
@@ -71,7 +71,11 @@
                             "Statement": [
                                 {
                                     "Effect": "Allow",
-                                    "Action": "rds:DeleteDBSnapshot",
+                                    "Action": [
+                                        "rds:DeleteDBSnapshot",
+                                        "rds:DescribeDBSnapshots",
+                                        "rds:StopDBInstance"
+                                    ],                                        
                                     "Resource": {
                                         "Fn::Join": [
                                             ":",


### PR DESCRIPTION
When using snapshots, both the DescribeDBSnaphot and StopDBInstance need to be applied to the snapshot resource also and not only to the rds resource