### PR TITLE
Revert "Update instance scheduler cross account role"

### DIFF
--- a/source/cloudformation/instance-scheduler-remote.template
+++ b/source/cloudformation/instance-scheduler-remote.template
@@ -71,11 +71,7 @@
                             "Statement": [
                                 {
                                     "Effect": "Allow",
-                                    "Action": [
-                                        "rds:DeleteDBSnapshot",
-                                        "rds:DescribeDBSnapshots",
-                                        "rds:StopDBInstance"
-                                    ],                                        
+                                    "Action": "rds:DeleteDBSnapshot",
                                     "Resource": {
                                         "Fn::Join": [
                                             ":",


### PR DESCRIPTION
*Issue #95

Description of changes:

When using snapshots, both the DescribeDBSnaphot and StopDBInstance need to be applied to the snapshot resource also and not only to the rds resource

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.